### PR TITLE
Simplify Window module

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,12 +3,9 @@ import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 import { FlightSearchComponent } from './pages/flight-search/flight-search.component';
 import { FlightTestPage } from './pages/flight-test/flight-test.page';
 import { WindowTabsPage } from './pages/window-tabs.page';
-import { WindowTextDataPage } from './pages/window-text-data.page';
-import { WindowMapPage } from './pages/window-map.page';
-import { WindowHublotPage } from './pages/window-hublot.page';
 
 const routes: Routes = [
-  { path: '', redirectTo: '/window/map', pathMatch: 'full' },
+  { path: '', redirectTo: '/window', pathMatch: 'full' },
   { path: 'search', component: FlightSearchComponent },
   { path: 'flight-details/:flightNumber', loadChildren: () => import('./pages/flight-details/flight-details.module').then(m => m.FlightDetailsModule) },
   {
@@ -18,12 +15,7 @@ const routes: Routes = [
   { path: 'flight-test', component: FlightTestPage },
   {
     path: 'window',
-    component: WindowPage
-  },
-      { path: 'map', component: WindowMapPage },
-      { path: 'hublot', component: WindowHublotPage },
-      { path: '', redirectTo: 'map', pathMatch: 'full' }
-    ]
+    component: WindowTabsPage
   }
 ];
 
@@ -33,4 +25,4 @@ const routes: Routes = [
   ],
   exports: [RouterModule]
 })
-export class AppRoutingModule { } 
+export class AppRoutingModule { }


### PR DESCRIPTION
## Summary
- revert complex Window pages to minimal placeholders
- clean up WindowService logic
- keep `/window` route for Ma Fenêtre

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684803988a48832e8b5924af195b9903